### PR TITLE
support random dest path

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -171,7 +171,7 @@ module.exports = {
 
     sortDependencies(data, green)
 
-    const cwd = path.join(process.cwd(), data.inPlace ? '' : data.destDirName)
+    const cwd = data.dest ? data.dest : path.join(process.cwd(), data.inPlace ? '' : data.destDirName)
 
     if (data.autoInstall) {
       installDependencies(cwd, data.autoInstall, green)

--- a/utils/index.js
+++ b/utils/index.js
@@ -10,10 +10,12 @@ const lintStyles = ['standard', 'airbnb']
  * @param {object} data Data from questionnaire
  */
 exports.sortDependencies = function sortDependencies(data) {
-  const packageJsonFile = path.join(
-    data.inPlace ? '' : data.destDirName,
-    'package.json'
-  )
+  let packageJsonFile;
+  if (data.dest) {
+    packageJsonFile = path.join(data.dest, 'package.json')
+  } else {
+    packageJsonFile = path.join(data.inPlace ? '' : data.destDirName,'package.json')
+  }
   const packageJson = JSON.parse(fs.readFileSync(packageJsonFile))
   packageJson.devDependencies = sortObject(packageJson.devDependencies)
   packageJson.dependencies = sortObject(packageJson.dependencies)


### PR DESCRIPTION
When using [weexpack-create](https://github.com/weexteam/weexpack-create) to create a weex project with a random assigned path, the template works well too.

```javascript
const weexpackCreate = require('weexpack-create');

weexpackCreate(
  randomPath, // e.g. /Users/xuzuo/work/learn-weex
  'learn-weex',
  'github-repository',
  true, // 支持randomPath
);
```

@erha19 