### PR TITLE
fix: use html-webpack-plugin-for-multihtml to increase compilation speed

### DIFF
--- a/template/configs/webpack.dev.conf.js
+++ b/template/configs/webpack.dev.conf.js
@@ -9,7 +9,7 @@ const ip = require('ip').address();
 /**
  * Webpack Plugins
  */
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin-for-multihtml');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin')
 const portfinder = require('portfinder')
@@ -51,6 +51,7 @@ const generateHtmlWebpackPlugin = (entry) => {
   entrys = entrys.filter(entry => entry !== 'vendor' );
   const htmlPlugin = entrys.map(name => {
     return new HtmlWebpackPlugin({
+      multihtmlCache: true,
       filename: name + '.html',
       template: helper.rootNode(`web/index.html`),
       isDevServer: true,

--- a/template/package.json
+++ b/template/package.json
@@ -85,6 +85,7 @@
     "extract-text-webpack-plugin": "^3.0.2",
     "friendly-errors-webpack-plugin": "^1.6.1",
     "fs-extra": "^5.0.0",
+    "html-webpack-plugin-for-multihtml": "^2.30.2",
     "glob": "^7.1.2",
     "html-webpack-plugin": "^2.30.1",
     "ip": "^1.1.5",


### PR DESCRIPTION
resolve  https://github.com/weexteam/weex-toolkit/issues/315

If we have many vue component. It will so slow when a minor change.

The reason is that every component of weex will generate a page, and each time HtmlWebpackPlugin is modified, it will analyze whether there is a file to modify.

For example, there are 30 files in my project.

Before optimization:

![image](https://user-images.githubusercontent.com/6399899/44964756-be5a9d00-af64-11e8-8bb0-012d675202fa.png)

After optimization:

![image](https://user-images.githubusercontent.com/6399899/44964786-daf6d500-af64-11e8-82c5-a1a677df859e.png)

Speed increased by 95%!!! 🎉

